### PR TITLE
Added Ignore Specials setting for Next Episodes

### DIFF
--- a/resources/lib/Entrypoint.py
+++ b/resources/lib/Entrypoint.py
@@ -278,7 +278,13 @@ def getNextUpEpisodes(tagname,limit):
     # If we found any, find the oldest unwatched show for each one.
     if json_result.has_key('result') and json_result['result'].has_key('tvshows'):
         for item in json_result['result']['tvshows']:
-            json_query2 = xbmc.executeJSONRPC('{"jsonrpc": "2.0", "method": "VideoLibrary.GetEpisodes", "params": { "tvshowid": %d, "sort": {"method":"episode"}, "filter": {"field": "playcount", "operator": "lessthan", "value":"1"}, "properties": [ "title", "playcount", "season", "episode", "showtitle", "plot", "file", "rating", "resume", "tvshowid", "art", "streamdetails", "firstaired", "runtime", "writer", "cast", "dateadded", "lastplayed" ], "limits":{"end":1}}, "id": "1"}' %item['tvshowid'])
+            addonSettings = xbmcaddon.Addon(id='plugin.video.emby')
+
+            # If Ignore Specials is true only choose episodes from seasons greater than 0.
+            if addonSettings.getSetting("ignoreSpecialsNextEpisodes")=="true":
+                json_query2 = xbmc.executeJSONRPC('{"jsonrpc": "2.0", "method": "VideoLibrary.GetEpisodes", "params": { "tvshowid": %d, "sort": {"method":"episode"}, "filter": {"and": [ {"field": "playcount", "operator": "lessthan", "value":"1"}, {"field": "season", "operator": "greaterthan", "value": "0"} ]}, "properties": [ "title", "playcount", "season", "episode", "showtitle", "plot", "file", "rating", "resume", "tvshowid", "art", "streamdetails", "firstaired", "runtime", "writer", "cast", "dateadded", "lastplayed" ], "limits":{"end":1}}, "id": "1"}' %item['tvshowid'])
+            else:
+                json_query2 = xbmc.executeJSONRPC('{"jsonrpc": "2.0", "method": "VideoLibrary.GetEpisodes", "params": { "tvshowid": %d, "sort": {"method":"episode"}, "filter": {"field": "playcount", "operator": "lessthan", "value":"1"}, "properties": [ "title", "playcount", "season", "episode", "showtitle", "plot", "file", "rating", "resume", "tvshowid", "art", "streamdetails", "firstaired", "runtime", "writer", "cast", "dateadded", "lastplayed" ], "limits":{"end":1}}, "id": "1"}' %item['tvshowid'])
 
             if json_query2:
                 json_query2 = json.loads(json_query2)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -32,6 +32,7 @@
 	</category>
 	<category label="Extras">
 	    <setting id="disableCoverArt" type="bool" label="30157" default="false" visible="true" enable="true" />
+        <setting id="ignoreSpecialsNextEpisodes" type="bool" label="Ignore specials in next episodes" visible="true" enable="true" default="false" />
 		<setting id="showSpecialInfoDialog" type="bool" label="Show special Emby infodialog on play" default="false" visible="false" />
 		<setting id="autoPlaySeason" type="bool" label="30246" default="false" visible="true" enable="true" />
 	    <setting id="autoPlaySeasonTime" type="number" label="30247" default="20" visible="eq(-1,true)" enable="true" />


### PR DESCRIPTION
Kodi labels specials as season 0. I find this annoying as hell as specials then come before regulars in next episodes. So I created a setting that allows you to ignore specials in next episodes. Nothing fancy, just an extra query with season greater than 0 filter.

Tested it out and it works great. Hope you'll merge it.