### PR TITLE
Fix verify_mode exception for ssl connections

### DIFF
--- a/emby/http.py
+++ b/emby/http.py
@@ -41,6 +41,7 @@ class HTTP:
         utils.start_thread(self.queued_request, ())
         self.ThreadsRunning = {"ASYNC": False, "DOWNLOAD": False, "QUEUEDREQUEST": True, "PING": False, "WEBSOCKET": False}
 
+        self.SSLContext.check_hostname = utils.sslverify
         if utils.sslverify:
             self.SSLContext.verify_mode = ssl.CERT_REQUIRED
         else:


### PR DESCRIPTION
Addresses issue [577](https://github.com/MediaBrowser/plugin.video.emby/issues/577).

In order to set verify_mode to CERT_NONE, check_hostname must be set to false. Otherwise, "cannot set verify_mode to cert_none when check_hostname" is thrown.
